### PR TITLE
Add error callbacks for xhr failures on image download.

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -159,26 +159,7 @@ var ImgCache = {
 			}
 		}
 		var xhr = new XMLHttpRequest();
-
-		// CORS/S3/Cloudfront compatibility
-		// For cloudfront, bust cache when origin changes.  ref: https://forums.aws.amazon.com/message.jspa?messageID=422504#422532  
-		// Make sure cloudfront distribution behavior is set to forward query strings, and S3 bucket CORS policy is set.  
-		// Permissive but workable S3 CORS policy: AllowedOrigin=*, AllowedMethod=GET, AllowedHeader=*.  
-		var crossDomain = /^http/.test(uri) && uri.indexOf(location.origin) != 0;
-		if (crossDomain) {
-			logging( 'Cross-domain support enabled', 1 );
-			uri = uri + ( uri.indexOf('?') < 0 ? '?' : '&') + "origin=" + encodeURIComponent(location.origin);
-		}
-
 		xhr.open('GET', uri, true);
-		
-		// Image in the browser cache may not have Access-Control-Allow-Origin set, since, for example, S3 does not send ACAO
-		// for a preceding GET that excluded Origin in its request (e.g. a GET resulting from <img src=...>).
-		// So XHR cannot use the cache (it likely wouldn't, since the Cloudfront cache-buster will also likely bust the browser cache).
-		if (crossDomain) {
-			xhr.setRequestHeader('Cache-Control', 'no-cache');
-		}
-
 		xhr.responseType = 'blob';
 		xhr.onload = function(event){
 			if (xhr.response && (xhr.status == 200 || xhr.status == 0)) {


### PR DESCRIPTION
Greetings - I wanted to share with you a minor fix I made, in case you want to pull it.

On chrome, ImgCache.cacheFile was failing without calling the fail_callback if xhr failed.  
So in chrome FileTransferWrapper, I added code to call the given error_callback when the xhr download fails.

It's not perfect, because on PhoneGap, the error parameter is a FileTransferError, while on chrome, it is a FileError if the write fails, and an object configured like a FileTransferError (with a code of 0) if the xhr fails.  For my purposes (and I hope for general use), it helps to call the error callback in any case, so the caller can deal with the failure.  

(To do: cast the Chrome FileWriter FileError into a FileTransferError, so ImgCache.cacheFile on Chrome returns the same type of error as on PhoneGap.)
