### PR TITLE
Avoid forcing img load from src attribute while retrieving cache.

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -387,8 +387,8 @@ var ImgCache = {
 
 
 	// $img: jQuery object of an <img/> element
-	ImgCache.useCachedFile = function($img, success_callback, fail_callback) {
-		_loadCachedFile($img, $img.attr('src'), _setNewImgPath, success_callback, fail_callback);
+	ImgCache.useCachedFile = function($img, img_src, success_callback, fail_callback) {
+		_loadCachedFile($img, img_src, _setNewImgPath, success_callback, fail_callback);
 	}
 
 	// clears the cache


### PR DESCRIPTION
As it was before, only the element to be filled with the cached image could be passed to useCachedFile.  The src value was then extracted from the element itself.  

However, this defeats the purpose of loading an image from cache, namely, that one may avoid making a network transaction.  If the element passed in already has a 'src' attribute (which it must in the previous implementation), the browser has already initiated the call to load that url.  

To amend this issue, useCachedFile now accepts two parameters, the element and the image url.  Now the img element will not attempt to load the url via network call before retrieving the image from the cache.  Of course, if you still wish to use the previous functionality, simply extract the src from the element in your function call.
