### PR TITLE
Cordova 3.4 compatibility

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -117,7 +117,7 @@ var ImgCache = {
 
 		img_src = Helpers.sanitizeURI(img_src);
 			
-		var filePath = Private.getCachedFilePath(img_src);
+		var filePath = Private.getCachedFileFullPath(img_src);
 
 		var fileTransfer = new Private.FileTransferWrapper(ImgCache.attributes.filesystem);
 		fileTransfer.download(
@@ -375,10 +375,13 @@ var ImgCache = {
 	// if no local_root set, set relative path
 	Private.getCachedFilePath = function(img_src) {
 		return ImgCache.options.localCacheFolder + '/' + Private.getCachedFileName(img_src);
-	//TODO: previously was:
-		//var local_root = Helpers.EntryGetPath(ImgCache.attributes.dirEntry);
-		//return (local_root ? local_root + '/' : '/') + Private.getCachedFileName(img_src);	
 	};
+
+	//returns full Cordova path (including cdvfile://)
+	Private.getCachedFileFullPath = function(img_src) {
+		var local_root = Helpers.EntryGetPath(ImgCache.attributes.dirEntry);
+		return (local_root ? local_root + '/' : '/') + Private.getCachedFileName(img_src);	
+	}
 	
 	Private.getCachedFileName = function(img_src) {
 		if (!img_src) {
@@ -632,9 +635,12 @@ var ImgCache = {
 	};
 	
 	Helpers.EntryGetPath = function(entry) {
-		// From Cordova 3.3 onward toURL() seems to be required instead of fullPath (#38)
-		return (entry.hasOwnProperty('toURL') ? entry.toURL() : entry.fullPath);
-	};
+        if (Private.isCordova()) {
+		    return (typeof entry.toURL == 'function' ? entry.toURL() : entry.fullPath);
+        } else {
+            return entry.fullPath;
+        }
+	}
 
 	Helpers.getCordovaStorageType = function(isPersistent) {
 		// From Cordova 3.1 onward those constants have moved to the window object (#38)


### PR DESCRIPTION
Introduced new helper method to get full path of cached file. `FileTransfer.download()` needs full path to local file, `File.exists()` needs just path to file.

Fixes #40, #41.

Tested on Android, iOS, Chrome
