### PR TITLE
device.platform in lowercase for Android

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -337,7 +337,7 @@ var ImgCache = {
 	};
 	
 	Private.isCordovaAndroid = function() {
-		return (Private.isCordova() && device && device.platform && device.platform.indexOf('android') >= 0);
+		return (Private.isCordova() && device && device.platform && device.platform.toLowerCase().indexOf('android') >= 0);
 	};
 
 	// special case for #47


### PR DESCRIPTION
On android emulator and some real devices `device.platform` is equal to 'Android', with an uppercase A, instead of 'android'.
