### PR TITLE
[bugfix] Use CustomEvent instead of Event

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -675,7 +675,7 @@ var ImgCache = {
 		if (ImgCache.jQuery) {
 			$(DomElement).trigger(eventName);
 		} else {
-			DomElement.dispatchEvent(new Event(eventName));
+			DomElement.dispatchEvent(new CustomEvent(eventName));
 		}
 	};
 


### PR DESCRIPTION
``` js
ImgCache.init()
TypeError: Illegal constructor
```

It's stack trace leads to this line:

``` js
DomElement.dispatchEvent(new Event(eventName));
```

I don't know if it's case with every Cordova device, but on my Cordova 3.3 and Android `new Event('foo')` raises a Error, while `new CustomEvent('foo')` is okay.
