### PR TITLE
Fix javascript error when running on Cordova iOS

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -338,7 +338,7 @@ var ImgCache = {
 	};
 	
 	Private.isCordovaAndroid = function() {
-		return (Private.isCordova() && device && device.platform && device.platform.indexOf('android') >= 0);
+		return (Private.isCordova() && /Android/.test(navigator.userAgent));
 	};
 
 	Private.isImgCacheLoaded = function() {


### PR DESCRIPTION
It seems that 'device' is not always available, not even after the device_ready event. The check in Private.isCordovaAndroid does attempt to provide for that situation, however it produces a javascript error if 'device' is not present.

Using a more reliable method to check if it is an Android device yields consistent results.
