### PR TITLE
Adding a getCachedFile method so users can use the FileEntry in other ways

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ ImgCache.isCached(target.attr('src'), function(path, success){
   }
 });
 ```
+
+To return the locally stored file:
+
+```javascript
+ImgCache.getCachedFile(target.attr('src'), function(path, fileEntry){
+  if(fileEntry){
+    // already cached, do something with FileEntry object
+  } else {
+    // not there, need to cache the image
+    ImgCache.cacheFile(target.attr('src'), function(){
+      ImgCache.useCachedFile(target);
+    });
+  }
+});
+```
     
 When you no longer want to use the locally cached file:
 

--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -161,10 +161,10 @@ var ImgCache = {
 		);
 	};
 
-	// checks if a copy of the file has already been cached
+	// Returns the file already available in the cached
 	// Reminder: this is an asynchronous method!
 	// Answer to the question comes in response_callback as the second argument (first being the path)
-	ImgCache.isCached = function(img_src, response_callback) {
+	ImgCache.getCachedFile = function(img_src, response_callback) {
 		// sanity check
 		if (!Private.isImgCacheLoaded() || !response_callback)
 			return;
@@ -179,16 +179,22 @@ var ImgCache = {
 				path = path.substr(7);
 			}
 		}
-		var ret = function(exists) {
-			response_callback(img_src, exists);
-		};
 		
 		// try to get the file entry: if it fails, there's no such file in the cache
 		ImgCache.attributes.filesystem.root.getFile(
 			path,
 			{ create: false },
-			function() { ret(true); },
-			function() { ret(false); });
+			function(file_entry) { response_callback(img_src, file_entry); },
+			function() { response_callback(img_src, null); });
+	};
+
+	// checks if a copy of the file has already been cached
+	// Reminder: this is an asynchronous method!
+	// Answer to the question comes in response_callback as the second argument (first being the path)
+	ImgCache.isCached = function(img_src, response_callback) {
+		ImgCache.getCachedFile(img_src, function(src, file_entry) {
+			response_callback(src, file_entry != null);	
+		});
 	};
 
 	// $img: jQuery object of an <img/> element


### PR DESCRIPTION
In our case, we'd like to use this library to store and cache audio files as well.  We'd like to play them at a later time and by using getCachedFile with returns a FileEntry object should let us do the job.  By adding a function like this we can allow this library to act as more of a generic cache as well.
