### PR TITLE
Let imgcache.js work with encoded URI's 

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -24,7 +24,8 @@ var ImgCache = {
 		chromeQuota: 10*1024*1024,					/* allocated cache space : here 10Mb */
 		usePersistentCache: true,					/* false: use temporary cache storage */
 		cacheClearSize : 0,             			/* size in Mb that triggers cache clear on init, 0 to disable */
-		headers: {}									/* HTTP headers for the download requests - e.g: headers: { 'Accept': 'application/jpg' } */
+		headers: {},									/* HTTP headers for the download requests - e.g: headers: { 'Accept': 'application/jpg' } */
+		skipURIencoding: false					/* enable if URI's are already encoded */
 		/* customLogger */							/* if function defined, will use this one to log events */
 	},
 	jQuery: (window.jQuery || window.Zepto) ? true : false,		/* using jQuery if it's available otherwise the DOM API */
@@ -589,14 +590,18 @@ var ImgCache = {
 	
 	// make sure the url does not contain funny characters like spaces that might make the download fail
 	Helpers.sanitizeURI = function(uri) {
-		var encodedURI = encodeURI(uri);
-		/*
-		TODO: The following bit of code will have to be checked first (#30)
-		if (Private.isCordova()) {
-			return encodedURI.replace(/%/g, '%25');
+		if (ImgCache.options.skipURIencoding) {
+			return uri;
+		} else {
+			var encodedURI = encodeURI(uri);
+			/*
+			TODO: The following bit of code will have to be checked first (#30)
+			if (Private.isCordova()) {
+				return encodedURI.replace(/%/g, '%25');
+			}
+			*/
+			return encodedURI;
 		}
-		*/
-		return encodedURI;
 	};
 	
 	// with a little help from http://code.google.com/p/js-uri/


### PR DESCRIPTION
I'm using imgcache.js in a Cordova application. The URI's of the images are retrieved from a JSON datasource, which provides encoded URI's. However, the Helpers.sanitizeURI always re-encodes the URI, which leads to double encoding. For example, this URI:
http://10.2.1.37:3000/api/avatars/137/The%20Dude_avatar.png

is encoded into:
http://10.2.1.37:3000/api/avatars/137/The%2520Dude_avatar.png

which is the incorrect URI for that image. 
I've solved it by adding an option to skip URI encoding, which is disabled by default.
