### PR TITLE
.getCachedFileUrl() method fixes #50

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -621,6 +621,22 @@ var ImgCache = {
             on_progress
 		);
 	};
+
+	// Returns the local url of a file already available in the cache
+	ImgCache.getCachedFileURL = function (img_src, success_callback, fail_callback) {
+
+	  var _getURL = function (img_src, entry) {
+	    if (!entry) {
+	      fail_callback(img_src, entry);
+	    } else {
+	      success_callback(img_src, Helpers.EntryGetURL(entry));
+	    }
+	  }
+
+	  ImgCache.getCachedFile(img_src, _getURL);
+
+	};
+
     
     // Returns the file already available in the cached
     // Reminder: this is an asynchronous method!


### PR DESCRIPTION
This does two things.  First, it fixes a regression from .70 where IS_MOCK is still tested for isCordova() cordova.

More importantly, it adds the 'low level' but very convenient function getCachedFileURL for easy convenience to the direct file url -- this is for contexts that are either divergent or more complex than the methods for replacing the IMG or background-image values.
