### PR TITLE
Much faster and lighter hashing of image src.

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -176,13 +176,9 @@ var ImgCache = {
         return (isPersistent ? window.PERSISTENT : window.TEMPORARY);
     };
 
-    /***********************************************
-	tiny-sha1 r4
-	MIT License
-	http://code.google.com/p/tiny-sha1/
-	***********************************************/
+    /***********************************************/
     /* jshint ignore:start */
-    Helpers.SHA1 = function(s){function U(a,b,c){while(0<c--)a.push(b)}function L(a,b){return(a<<b)|(a>>>(32-b))}function P(a,b,c){return a^b^c}function A(a,b){var c=(b&0xFFFF)+(a&0xFFFF),d=(b>>>16)+(a>>>16)+(c>>>16);return((d&0xFFFF)<<16)|(c&0xFFFF)}var B="0123456789abcdef";return(function(a){var c=[],d=a.length*4,e;for(var i=0;i<d;i++){e=a[i>>2]>>((3-(i%4))*8);c.push(B.charAt((e>>4)&0xF)+B.charAt(e&0xF))}return c.join('')}((function(a,b){var c,d,e,f,g,h=a.length,v=0x67452301,w=0xefcdab89,x=0x98badcfe,y=0x10325476,z=0xc3d2e1f0,M=[];U(M,0x5a827999,20);U(M,0x6ed9eba1,20);U(M,0x8f1bbcdc,20);U(M,0xca62c1d6,20);a[b>>5]|=0x80<<(24-(b%32));a[(((b+65)>>9)<<4)+15]=b;for(var i=0;i<h;i+=16){c=v;d=w;e=x;f=y;g=z;for(var j=0,O=[];j<80;j++){O[j]=j<16?a[j+i]:L(O[j-3]^O[j-8]^O[j-14]^O[j-16],1);var k=(function(a,b,c,d,e){var f=(e&0xFFFF)+(a&0xFFFF)+(b&0xFFFF)+(c&0xFFFF)+(d&0xFFFF),g=(e>>>16)+(a>>>16)+(b>>>16)+(c>>>16)+(d>>>16)+(f>>>16);return((g&0xFFFF)<<16)|(f&0xFFFF)})(j<20?(function(t,a,b){return(t&a)^(~t&b)}(d,e,f)):j<40?P(d,e,f):j<60?(function(t,a,b){return(t&a)^(t&b)^(a&b)}(d,e,f)):P(d,e,f),g,M[j],O[j],L(c,5));g=f;f=e;e=L(d,30);d=c;c=k}v=A(v,c);w=A(w,d);x=A(x,e);y=A(y,f);z=A(z,g)}return[v,w,x,y,z]}((function(t){var a=[],b=255,c=t.length*8;for(var i=0;i<c;i+=8){a[i>>5]|=(t.charCodeAt(i/8)&b)<<(24-(i%32))}return a}(s)).slice(),s.length*8))))};
+    Helpers.Hash = function(c){var a=0,d,b;if(0==c.length)return a;for(b=0;b<c.length;b++)d=c.charCodeAt(b),a=(a<<5)-a+d;return a};
     /* jshint ignore:end */
     /***********************************************/
 
@@ -276,7 +272,7 @@ var ImgCache = {
             return Private.attributes.hasLocalStorage;
 
         try {
-            var mod = Helpers.SHA1('imgcache_test');
+            var mod = Helpers.Hash('imgcache_test');
             localStorage.setItem(mod, mod);
             localStorage.removeItem(mod);
             Private.attributes.hasLocalStorage = true;
@@ -311,7 +307,7 @@ var ImgCache = {
             Helpers.logging('No source given to getCachedFileName', LOG_LEVEL_WARNING);
             return;
         }
-        var hash = Helpers.SHA1(img_src);
+        var hash = Helpers.Hash(img_src);
         var ext = Helpers.FileGetExtension(Helpers.URIGetFileName(img_src));
         return hash + (ext ? ('.' + ext) : '');
     };


### PR DESCRIPTION
Tiny-SHA1 is big and really slow for just getting a hash of the image src. The function I've replaced it with is over 100x faster (in JSPerf tests) as well as much smaller.
