### PR TITLE
Update imgcache.js

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -531,7 +531,9 @@ var ImgCache = {
 		};
 		if (Helpers.isCordova()) {
 			// PHONEGAP
-            window.requestFileSystem(Helpers.getCordovaStorageType(ImgCache.options.usePersistentCache), 0, _gotFS, _fail);
+			document.addEventListener("deviceready", function() {
+                                window.requestFileSystem(Helpers.getCordovaStorageType(ImgCache.options.usePersistentCache), 0, _gotFS, _fail);
+                        }, false);
 		} else {
 			//CHROME
 			window.requestFileSystem  = window.requestFileSystem || window.webkitRequestFileSystem;


### PR DESCRIPTION
wrapping this in a deviceready listener as is needed by line 535 to run without error. 

Without deviceready, an undefined will be returned by the getCordovaStorageType function.

This should be added in other places too but as this is the entry point it should suffice.
