### PR TITLE
IOS Image Caching fix

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -160,6 +160,10 @@ var ImgCache = {
     // Returns the full absolute path from the root to the FileEntry
     Helpers.EntryGetPath = function (entry) {
         if (Helpers.isCordova()) {
+        //On iOS only the fullPath works because toURL returns path with localhost
+        if (device.platform.toLowerCase() == "ios") {
+                return entry.fullPath
+            }
             // From Cordova 3.3 onward toURL() seems to be required instead of fullPath (#38)
             return (typeof entry.toURL === 'function' ? Helpers.EntryToURL(entry) : entry.fullPath);
         } else {


### PR DESCRIPTION
On iOS only the fullPath works because toURL returns path with localhost.

Correct File Path:
file://var/mobile/Applications/A453F0BF-92E6-46C7-9BA4-A7B75C91C186/Documents/imageCache/c5a56e15d9954186cd95f89a9f23c2e73e7dbf57.png