### PR TITLE
Added package.json to make this module publishable to NPM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "imgcache.js",
+  "version": "1.0.0",
+  "description": "JS library based on the File API to cache images for offline recovery (target: cordova/phonegap & chrome)",
+  "main": "js/imgcache.js",
+  "directories": {
+    "example": "examples"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/chaddjohnson/imgcache.js.git"
+  },
+  "keywords": [
+    "image",
+    "cache",
+    "html5",
+    "file",
+    "filesystem",
+    "offline"
+  ],
+  "author": "Christophe BENOIT",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/chrisben/imgcache.js/issues"
+  },
+  "homepage": "https://github.com/chaddjohnson/imgcache.js"
+}


### PR DESCRIPTION
I need imgcache.js pulled into my project via NPM so that I can use it with Browserify. I noticed imgcache.js is not published to NPM, so I went ahead and added package.json and published this package to NPM. I did so because I want to install imgcache.js to node_modules, and I don't necessarily want to have to commit the node_modules directory to my project's repository.

The package is published here: https://www.npmjs.com/package/imgcache.js

I've listed you as the author (without an email address).

I was also forced to set the version at 1.0.0 instead of 1.0rc1 ("npm init" was erroring out otherwise).

If you'd like to merge package.json into your imgcache.js repository, feel free; here is a pull request.

Let me know if you need anything. I'm happy to (assuming it's possible) take imgcache.js down from NPM and let you publish it yourself, under your name, if you would like -- just let me know if you wish to have it that way.