### PR TITLE
Set the jQuery and jQueryLite properties on ImgCache.init()

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
             LOG_LEVEL_ERROR = 3,
             logger = function (str, level) {
                 var levelClass = '';
-                if (level == LOG_LEVEL_INFO) { levelClass = 'info' } ;
-                if (level == LOG_LEVEL_WARNING) { levelClass = 'warn' };
-                if (level == LOG_LEVEL_ERROR) { levelClass = 'error' };
+                if (level == LOG_LEVEL_INFO) { levelClass = 'info'; }
+                if (level == LOG_LEVEL_WARNING) { levelClass = 'warn'; }
+                if (level == LOG_LEVEL_ERROR) { levelClass = 'error'; }
                 $('#log').append($('<li></li>').addClass(levelClass).text(str));
             };
 

--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -47,8 +47,6 @@ var ImgCache = {
                     }
             }
         },
-        jQuery: (window.jQuery || window.Zepto) ? true : false,        /* using jQuery if it's available otherwise the DOM API */
-        jQueryLite: (typeof window.angular !== 'undefined' && window.angular.element) ? true : false,    /* is AngularJS jQueryLite available */
         ready: false,
         attributes: {}
     },
@@ -127,18 +125,8 @@ var ImgCache = {
         return ext;
     };
 
-    Helpers.hasJqueryOrFunctions = function (element) {
-        if (ImgCache.jQuery || ImgCache.jQueryLite) {
-            return true;
-        } else {
-            var functions = Array.prototype.slice.call(arguments);
-            functions.shift();
-            functions.forEach(function(fn) {
-                if (element[fn] === undefined)
-                    return false;
-            });
-            return true;
-        }
+    Helpers.hasJqueryOrJQueryLite = function (element) {
+        return (ImgCache.jQuery || ImgCache.jQueryLite); 
     };
 
     Helpers.isCordova = function () {
@@ -250,28 +238,28 @@ var ImgCache = {
     };
 
     DomHelpers.removeAttribute = function (element, attrName) {
-        if (Helpers.hasJqueryOrFunctions(element, 'removeAttr')) {
+        if (Helpers.hasJqueryOrJQueryLite()) {
             element.removeAttr(attrName);
         } else {
             element.removeAttribute(attrName);
         }
     };
     DomHelpers.setAttribute = function (element, attrName, value) {
-        if (Helpers.hasJqueryOrFunctions(element, 'attr')) {
+        if (Helpers.hasJqueryOrJQueryLite()) {
             element.attr(attrName, value);
         } else {
             element.setAttribute(attrName, value);
         }
     };
     DomHelpers.getAttribute = function (element, attrName) {
-        if (Helpers.hasJqueryOrFunctions(element, 'attr')) {
+        if (Helpers.hasJqueryOrJQueryLite()) {
             return element.attr(attrName);
         } else {
             return element.getAttribute(attrName);
         }
     };
     DomHelpers.getBackgroundImage = function (element) {
-        if (Helpers.hasJqueryOrFunctions(element, 'attr', 'css')) {
+        if (Helpers.hasJqueryOrJQueryLite()) {
             return element.attr('data-old-background') ? "url(" + element.attr('data-old-background') + ")" : element.css('background-image');
         } else {
             var style = window.getComputedStyle(element, null);
@@ -282,7 +270,7 @@ var ImgCache = {
         }
     };
     DomHelpers.setBackgroundImage = function (element, styleValue) {
-        if (Helpers.hasJqueryOrFunctions(element, 'css')) {
+        if (Helpers.hasJqueryOrJQueryLite()) {
             element.css('background-image', styleValue);
         } else {
             element.style.backgroundImage = styleValue;
@@ -546,6 +534,9 @@ var ImgCache = {
         IMGCACHE_READY_TRIGGERED_EVENT = 'ImgCacheReady';
 
     ImgCache.init = function (success_callback, error_callback) {
+        ImgCache.jQuery = (window.jQuery || window.Zepto) ? true : false;        /* using jQuery if it's available otherwise the DOM API */
+        ImgCache.jQueryLite = (typeof window.angular !== 'undefined' && window.angular.element) ? true : false;    /* is AngularJS jQueryLite available */
+
         ImgCache.attributes.init_callback = success_callback;
 
         ImgCache.overridables.log('ImgCache initialising', LOG_LEVEL_INFO);

--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -33,7 +33,9 @@ var ImgCache = {
         overridables: {
             hash: function (s) {
                 /* tiny-sha1 r4 (11/2011) - MIT License - http://code.google.com/p/tiny-sha1/ */
+                /* jshint ignore:start */
                 function U(a,b,c){while(0<c--)a.push(b)}function L(a,b){return(a<<b)|(a>>>(32-b))}function P(a,b,c){return a^b^c}function A(a,b){var c=(b&0xFFFF)+(a&0xFFFF),d=(b>>>16)+(a>>>16)+(c>>>16);return((d&0xFFFF)<<16)|(c&0xFFFF)}var B="0123456789abcdef";return(function(a){var c=[],d=a.length*4,e;for(var i=0;i<d;i++){e=a[i>>2]>>((3-(i%4))*8);c.push(B.charAt((e>>4)&0xF)+B.charAt(e&0xF))}return c.join('')}((function(a,b){var c,d,e,f,g,h=a.length,v=0x67452301,w=0xefcdab89,x=0x98badcfe,y=0x10325476,z=0xc3d2e1f0,M=[];U(M,0x5a827999,20);U(M,0x6ed9eba1,20);U(M,0x8f1bbcdc,20);U(M,0xca62c1d6,20);a[b>>5]|=0x80<<(24-(b%32));a[(((b+65)>>9)<<4)+15]=b;for(var i=0;i<h;i+=16){c=v;d=w;e=x;f=y;g=z;for(var j=0,O=[];j<80;j++){O[j]=j<16?a[j+i]:L(O[j-3]^O[j-8]^O[j-14]^O[j-16],1);var k=(function(a,b,c,d,e){var f=(e&0xFFFF)+(a&0xFFFF)+(b&0xFFFF)+(c&0xFFFF)+(d&0xFFFF),g=(e>>>16)+(a>>>16)+(b>>>16)+(c>>>16)+(d>>>16)+(f>>>16);return((g&0xFFFF)<<16)|(f&0xFFFF)})(j<20?(function(t,a,b){return(t&a)^(~t&b)}(d,e,f)):j<40?P(d,e,f):j<60?(function(t,a,b){return(t&a)^(t&b)^(a&b)}(d,e,f)):P(d,e,f),g,M[j],O[j],L(c,5));g=f;f=e;e=L(d,30);d=c;c=k}v=A(v,c);w=A(w,d);x=A(x,e);y=A(y,f);z=A(z,g)}return[v,w,x,y,z]}((function(t){var a=[],b=255,c=t.length*8;for(var i=0;i<c;i+=8){a[i>>5]|=(t.charCodeAt(i/8)&b)<<(24-(i%32))}return a}(s)).slice(),s.length*8))));
+                /* jshint ignore:end */
             },
             log: function (str, level) {
                     'use strict';
@@ -123,6 +125,20 @@ var ImgCache = {
             return '';
         }
         return ext;
+    };
+
+    Helpers.hasJqueryOrFunctions = function (element) {
+        if (ImgCache.jQuery || ImgCache.jQueryLite) {
+            return true;
+        } else {
+            var functions = Array.prototype.slice.call(arguments);
+            functions.shift();
+            functions.forEach(function(fn) {
+                if (element[fn] === undefined)
+                    return false;
+            });
+            return true;
+        }
     };
 
     Helpers.isCordova = function () {
@@ -234,28 +250,28 @@ var ImgCache = {
     };
 
     DomHelpers.removeAttribute = function (element, attrName) {
-        if (ImgCache.jQuery || ImgCache.jQueryLite) {
+        if (Helpers.hasJqueryOrFunctions(element, 'removeAttr')) {
             element.removeAttr(attrName);
         } else {
             element.removeAttribute(attrName);
         }
     };
     DomHelpers.setAttribute = function (element, attrName, value) {
-        if (ImgCache.jQuery || ImgCache.jQueryLite) {
+        if (Helpers.hasJqueryOrFunctions(element, 'attr')) {
             element.attr(attrName, value);
         } else {
             element.setAttribute(attrName, value);
         }
     };
     DomHelpers.getAttribute = function (element, attrName) {
-        if (ImgCache.jQuery || ImgCache.jQueryLite) {
+        if (Helpers.hasJqueryOrFunctions(element, 'attr')) {
             return element.attr(attrName);
         } else {
             return element.getAttribute(attrName);
         }
     };
     DomHelpers.getBackgroundImage = function (element) {
-        if (ImgCache.jQuery || ImgCache.jQueryLite) {
+        if (Helpers.hasJqueryOrFunctions(element, 'attr', 'css')) {
             return element.attr('data-old-background') ? "url(" + element.attr('data-old-background') + ")" : element.css('background-image');
         } else {
             var style = window.getComputedStyle(element, null);
@@ -266,7 +282,7 @@ var ImgCache = {
         }
     };
     DomHelpers.setBackgroundImage = function (element, styleValue) {
-        if (ImgCache.jQuery || ImgCache.jQueryLite) {
+        if (Helpers.hasJqueryOrFunctions(element, 'css')) {
             element.css('background-image', styleValue);
         } else {
             element.style.backgroundImage = styleValue;

--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -125,7 +125,7 @@ var ImgCache = {
         return ext;
     };
 
-    Helpers.hasJqueryOrJQueryLite = function (element) {
+    Helpers.hasJqueryOrJqueryLite = function (element) {
         return (ImgCache.jQuery || ImgCache.jQueryLite); 
     };
 
@@ -238,28 +238,28 @@ var ImgCache = {
     };
 
     DomHelpers.removeAttribute = function (element, attrName) {
-        if (Helpers.hasJqueryOrJQueryLite()) {
+        if (Helpers.hasJqueryOrJqueryLite()) {
             element.removeAttr(attrName);
         } else {
             element.removeAttribute(attrName);
         }
     };
     DomHelpers.setAttribute = function (element, attrName, value) {
-        if (Helpers.hasJqueryOrJQueryLite()) {
+        if (Helpers.hasJqueryOrJqueryLite()) {
             element.attr(attrName, value);
         } else {
             element.setAttribute(attrName, value);
         }
     };
     DomHelpers.getAttribute = function (element, attrName) {
-        if (Helpers.hasJqueryOrJQueryLite()) {
+        if (Helpers.hasJqueryOrJqueryLite()) {
             return element.attr(attrName);
         } else {
             return element.getAttribute(attrName);
         }
     };
     DomHelpers.getBackgroundImage = function (element) {
-        if (Helpers.hasJqueryOrJQueryLite()) {
+        if (Helpers.hasJqueryOrJqueryLite()) {
             return element.attr('data-old-background') ? "url(" + element.attr('data-old-background') + ")" : element.css('background-image');
         } else {
             var style = window.getComputedStyle(element, null);
@@ -270,7 +270,7 @@ var ImgCache = {
         }
     };
     DomHelpers.setBackgroundImage = function (element, styleValue) {
-        if (Helpers.hasJqueryOrJQueryLite()) {
+        if (Helpers.hasJqueryOrJqueryLite()) {
             element.css('background-image', styleValue);
         } else {
             element.style.backgroundImage = styleValue;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "git://github.com/chaddjohnson/imgcache.js.git"
   },
+  "scripts": {
+    "test": "open '/Applications/Google Chrome.app' 'index.html' --args --allow-file-access-from-files --allow-file-access"
+  },
   "keywords": [
     "image",
     "cache",


### PR DESCRIPTION
Hey chrisben,

Here's a small fix that'll allow imgcache.js to work with AngularJS regardless of whether it is loaded before or after Angular on the page. The way it currently is setup, it will set jQuery and jQueryLite to false if you haven't got the `window.angular` object setup when it loads on the page -- This causes errors later on when it tries to use the `element.getAttribute(attrName)` method, because AngularJS's `angular.element` doesn't have that method.

Thanks for your work on this plugin! I've got a few other ideas for improvements as well that I might offer up in the  not too distant future as well. 

Best,
Flinn