### PR TITLE
Expose getCachedFileData() method to get base64 data from cache.

### DIFF
--- a/js/qimgcache.js
+++ b/js/qimgcache.js
@@ -105,6 +105,21 @@ var QImgCache = {};
         });
     };
 
+    QImgCache.getCachedFileData = function (url) {
+        return initCheck(function (def) {
+            ImgCache.getCachedFileData(
+                url,
+                function(img_src, base64content) {
+                    if (base64content === null) {
+                        def.reject();
+                    } else {
+                        def.resolve(base64content);
+                    }
+                }
+            );
+        });
+    };
+
     // $img: jQuery or DOM element for the <img/> element
     QImgCache.useCachedFile = function ($img) {
         return initCheck(function (def) {


### PR DESCRIPTION
Some times we want to get directly the base64 data from cache, not an url. With this method, extracted from Private.loadCachedFile(), you can get it easily. Qimage method is implemented too.
