### PR TITLE
Added an option for complying with iOS/etc file storage location guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ ImgCache.options.debug = true;
 
 // increase allocated space on Chrome to 50MB, default was 10MB
 ImgCache.options.chromeQuota = 50*1024*1024;
+
+// Instead of using the PERSISTENT or TEMPORARY filesystems, use one of the
+// Cordova File plugin's app directories
+// (https://github.com/apache/cordova-plugin-file#where-to-store-files).
+// This is friendlier in a mobile application environment as we are able to store
+// files in the correct platform-recommended/enforced directories.
+// WARNING: Make sure this points to a __directory__!
+// NOTE: Only has effect when running in a Cordova environment
+ImgCache.options.cordovaFilesystemRoot = cordova.file.dataDirectory;
 ```
 
 See `ImgCache.options` at the top of the source file for more settings.

--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -569,7 +569,24 @@ var ImgCache = {
         };
         if (Helpers.isCordova()) {
             // PHONEGAP
-            window.requestFileSystem(Helpers.getCordovaStorageType(ImgCache.options.usePersistentCache), 0, _gotFS, _fail);
+            if(ImgCache.options.cordovaFilesystemRoot) {
+                try {
+                    window.resolveLocalFileSystemURL(
+                        ImgCache.options.cordovaFilesystemRoot,
+                        function (dirEntry) {
+                            _gotFS({ root: dirEntry });
+                        },
+                        function (e) {
+                            if(typeof e == "object") _fail(e);
+                            else _fail({}); // no idea whether the error callback is guaranteed to be called with an object argument
+                        }
+                    );
+                } catch (e) {
+                    _fail({ code: e.message })
+                }
+            } else {
+                window.requestFileSystem(Helpers.getCordovaStorageType(ImgCache.options.usePersistentCache), 0, _gotFS, _fail);
+            }
         } else {
             //CHROME
             window.requestFileSystem  = window.requestFileSystem || window.webkitRequestFileSystem;


### PR DESCRIPTION
Added an option `ImgCache.options.cordovaFilesystemRoot` to set a custom filesystem root, to ease compliance with mobile platform recommended/enforced file storage locations.

For example, we may want to save cached images to `<app>/Library/NoCloud` on iOS. We can do that by setting `ImgCache.options.cordovaFilesystemRoot = cordova.file.dataDirectory;`

More common file storage locations can be found at Cordova File plugin's [Documentation](https://github.com/apache/cordova-plugin-file#where-to-store-files)
