### PR TITLE
fix for #97

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -165,7 +165,7 @@ var ImgCache = {
         if (Helpers.isCordovaAndroidOlderThan4() && typeof entry.toNativeURL === 'function') {
             return entry.toNativeURL();
         } else {
-            return entry.toURL();
+            return entry.toInternalURL();
         }
     };
 

--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -125,8 +125,8 @@ var ImgCache = {
         return ext;
     };
 
-    Helpers.hasJqueryOrJqueryLite = function () {
-        return (ImgCache.jQuery || ImgCache.jQueryLite); 
+    Helpers.hasJqueryOrJqueryLite = function (element) {
+        return (ImgCache.jQuery || ImgCache.jQueryLite);
     };
 
     Helpers.isCordova = function () {
@@ -163,9 +163,10 @@ var ImgCache = {
     // Fix for #42 (Cordova versions < 4.0)
     Helpers.EntryToURL = function (entry) {
         if (Helpers.isCordovaAndroidOlderThan4() && typeof entry.toNativeURL === 'function') {
-            return entry.toNativeURL();
-        } else {
-            return entry.toInternalURL();
+			  return entry.toNativeURL();
+		  } else {
+			  //fixes undefined is not function on chrome
+			  return entry.toInternalURL ? entry.toInternalURL() : entry.toURL();
         }
     };
 


### PR DESCRIPTION
This fixes #97 for me, although I really would like if someone else could test that it doesn't break stuff on their devices or versions.

It might need a more solid check for what version of cordova is running.

I've tested it on
* iOS Simulator running iOS 8.2 and cordova 4.3.0
* Android Phone running Android 5.0 and cordova 4.1.2

Both seemed to work just fine.