### PR TITLE
Fixes #132 failed to INIT with cordova + windows phone 8.1

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -138,7 +138,7 @@ var ImgCache = {
     };
 
     Helpers.isCordovaWindowsPhone = function () {
-        return (Helpers.isCordova() && device && device.platform && device.platform.toLowerCase().indexOf('win32nt') >= 0);
+        return (Helpers.isCordova() && device && device.platform && ((device.platform.toLowerCase().indexOf('win32nt') >= 0) || (device.platform.toLowerCase().indexOf('windows') >= 0)));
     };
 
     Helpers.isCordovaIOS = function () {


### PR DESCRIPTION
Added fix provided by badpenguin
This allows imgacache.js to work properly in cordova windows platform (Windows 8.1+ phone or desktop)