### PR TITLE
Move package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,5 +6,5 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom(["METEOR@0.9.5", "METEOR@1.1.0.2"]);
-  api.addFiles("../js/imgcache.js");
+  api.addFiles("js/imgcache.js");
 });


### PR DESCRIPTION
The colon in “chrisben:imgcache” is invalid in some filesystems as stated in #125.