### PR TITLE
Update angular-imgcache location

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ See also
 --------
 Wrappers for AngularJS:
 
-* [angular-imgcache.js](https://github.com/jBenes/angular-imgcache.js)
+* [angular-imgcache.js](https://github.com/maistho/angular-imgcache.js)
 * [ngImgCache](https://github.com/sunsus/ngImgCache/)
 
 License


### PR DESCRIPTION
Hello,

It seems that I am the new maintainer of [angular-imgcache.js](https://github.com/maistho/angular-imgcache.js). The old repo isn't working, and JBenes is very unresponsive, although said that he/she would work to transfer the repo. (https://github.com/jBenes/angular-imgcache.js/issues/19)

I feel the best way to save some headache for people trying to use the broken version is to point the link towards my fork instead.