### PR TITLE
Fix spaces in names

### DIFF
--- a/js/imgcache.js
+++ b/js/imgcache.js
@@ -788,8 +788,9 @@ var ImgCache = {
         if (!Private.isImgCacheLoaded()) {
             return;
         }
-
-        Private.loadCachedFile($img, DomHelpers.getAttribute($img, 'src'), Private.setNewImgPath, success_callback, error_callback);
+        var image_url = DomHelpers.getAttribute($img, 'src');
+        var img_src = Helpers.sanitizeURI(image_url);
+        Private.loadCachedFile($img, img_src, Private.setNewImgPath, success_callback, error_callback);
     };
 
     // When the source url is not the 'src' attribute of the given img element


### PR DESCRIPTION
File names with spaces in name are not found in cache.
This is caused by routine useCachedFile taking the src attribute without sanitizing the filename.