### PR TITLE
Fixes the issue "Failed to load resource"

### DIFF
--- a/lib/imgcache.js
+++ b/lib/imgcache.js
@@ -188,6 +188,8 @@ LOG_LEVEL_ERROR = 3;
   Helpers.EntryToURL = function (entry) {
     if (Helpers.isCordovaAndroidOlderThan4() && typeof entry.toNativeURL === 'function') {
       return entry.toNativeURL();
+    } else if (!!window.WkWebView && typeof window.WkWebView.convertFilePath === 'function') {
+      return window.WkWebView.convertFilePath(entry.toURL());
     } else if (
         !Helpers.isIonicNormalizerFunctionExist() && // Fix for #223 #237 #246
         (typeof entry.toInternalURL === 'function')) {


### PR DESCRIPTION
Without this change the cached file path shows up in the following format (for cordova-ios 6.1.0, with scheme set to cdvfile and hostname set to localhost in config file):

cdvfile://localhost/library-nosync/imgcache/hashedfilename.jpg

System cannot find the file there. Hence, it throws the error "Failed to load resource: the server responded with a status of 404 ()"

After making this change, the cached file path shows up as:

cdvfile://localhost/_app_file_/var/mobile/Containers/Data/Application/approotdirectoryname/Library/NoCloud/imgcache/hashedfilename.jpg

which is where the cached file is actually located.