### PR TITLE
Replace toInternalURL() with toURL() for Android

### DIFF
--- a/lib/imgcache.js
+++ b/lib/imgcache.js
@@ -188,6 +188,8 @@ LOG_LEVEL_ERROR = 3;
   Helpers.EntryToURL = function (entry) {
     if (Helpers.isCordovaAndroidOlderThan4() && typeof entry.toNativeURL === 'function') {
       return entry.toNativeURL();
+    } else if (Helpers.isCordovaAndroid()) { // use toURL for newer versions of Cordova Android
+      return entry.toURL();
     } else if (window.WkWebView && typeof window.WkWebView.convertFilePath === 'function') {
       return window.WkWebView.convertFilePath(entry.toURL());
     } else if (


### PR DESCRIPTION
When the plugin is used in newer versions of Android, it always uses toInternalURL() instead of toURL(). When using toInternalURL() for Android, the plugin is unable to download and save or retrieve any cache files since the url provided by toInternalURL() is invalid.

By adding the above checking, this will solve the issue completely. Feel free to refactor the code if this fix doesn't apply to all scenarios tested.